### PR TITLE
Supports requests using multipart/form-data

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -157,6 +157,26 @@ begin
 > **NOTE:** Async request is only supported for `WinHTTP`.
 > Any thought about how to implement this feature for `Indy` and `WinInet` are welcome.
 
+- **MULTIPART/FORM-DATA**
+
+Send forms with file attachments is possible by declaring a class that represents the form fields and inherits from `TMultiPartFormData`.
+
+```Delphi   
+  TRequestData = class(TMultiPartFormData)
+    name: string;
+    ticket_number: integer;
+    signed_contract: TMultiPartFormAttachment;
+  end;
+```
+```Delphi
+  Request := TRequestData.Create;
+  Request.name := 'Fernando'; 
+  Request.ticket_number := 123; 
+  Request.signed_contract := TMultiPartFormAttachment.Create('c:\contract.txt', 'text/plain', 'contract.txt');
+
+  Result := RestClient.Resource(URL).Post(Request);
+```
+
 ## Authentication
 
 RestClient supports HTTP Basic authentication. You can set credentials using the `SetCredentials` method before making the first request:

--- a/src/RestClient.pas
+++ b/src/RestClient.pas
@@ -926,12 +926,15 @@ procedure TResource.SetContent(entity: TObject);
 var
   vRawContent: string;
   vStream: TStringStream;
+  {$IFDEF SUPPORTS_GENERICS}
   vMultipartFormData: TMultipartFormData;
+  {$ENDIF}
 begin
   FContent.Clear;
   if not Assigned(entity) then
     Exit;
 
+  {$IFDEF SUPPORTS_GENERICS}
   if entity is TMultipartFormData then
   begin
     vMultipartFormData := TMultipartFormData(entity);
@@ -939,6 +942,7 @@ begin
     ContentType(vMultipartFormData.ContentType);
   end
   else
+  {$ENDIF}
     vRawContent := TJsonUtil.Marshal(Entity);
 
   vStream := TStringStream.Create(vRawContent);


### PR DESCRIPTION
Declaration:
```
TRequestData = class(TMultiPartFormData)
  Name: string;
  Document: TMultiPartFormAttachment;
end;
```
Usage:
```
 Request := TRequestData.Create;
 Request.Name := 'Fernando'; 
 Request.Document := TMultiPartFormAttachment.Create('c:\sample.txt', 'text/plain', 'sample.txt');

 Result := RestClient.Resource(URL).Post<TResultType>(Request);
```