### PR TITLE
Returns zero in float conversion when field not found

### DIFF
--- a/lib/superobject/superobject.pas
+++ b/lib/superobject/superobject.pas
@@ -6577,7 +6577,8 @@ function TSuperRttiContext.FromJson(TypeInfo: PTypeInfo; const obj: ISuperObject
           Result := False;
       end
     else
-       Result := False;
+      TValueData(Value).FAsCurr := 0;
+      Result := True;
     end;
   end;
 


### PR DESCRIPTION
Se retornar False na conversão, todo o processo é abortado. Isso ocorre porque o field existe na classe mas não foi encontrado no json, pra outros tipo ele preenche o valor padrão, acredito que pra float, currency, etc, deveria retornar zero ao invés de gerar erro.